### PR TITLE
Fix error in parsing => by extract_quotelike

### DIFF
--- a/lib/Text/Balanced.pm
+++ b/lib/Text/Balanced.pm
@@ -794,6 +794,19 @@ sub _match_quotelike($$$$)      # ($textref, $prepat, $allow_raw_match)
     }
     pos($$textref) = $ld1pos;   # HAVE TO DO THIS BECAUSE LOOKAHEAD BROKEN
     my ($ldel1, $rdel1) = ("\Q$1","\Q$1");
+
+    if ($ldel1 eq '\=') {
+        if (substr($$textref, $str1pos, 1) eq '>') {
+            # special case for =>
+            {
+                _failmsg "Fat comma not quotelike",
+                pos $$textref;
+                pos $$textref = $startpos;
+                return;
+            }
+        }
+    }
+
     if ($ldel1 =~ /[[(<{]/)
     {
         $rdel1 =~ tr/[({</])}>/;
@@ -812,7 +825,9 @@ sub _match_quotelike($$$$)      # ($textref, $prepat, $allow_raw_match)
     my $second_arg = $op =~ /s|tr|y/ ? 1 : 0;
     if ($second_arg)
     {
+
         my ($ldel2, $rdel2);
+
         if ($ldel1 =~ /[[(<{]/)
         {
             unless ($$textref =~ /\G\s*(\S)/gc) # SHOULD USE LOOKAHEAD

--- a/t/03_extcbk.t
+++ b/t/03_extcbk.t
@@ -11,14 +11,14 @@ use strict;
 # (It may become useful if the test is moved to ./t subdirectory.)
 
 my $loaded = 0;
-BEGIN { $| = 1; print "1..41\n"; }
+BEGIN { $| = 1; print "1..49\n"; }
 END {print "not ok 1\n" unless $loaded;}
 use Text::Balanced qw ( extract_codeblock );
 $loaded = 1;
 print "ok 1\n";
 my $count=2;
-use vars qw( $DEBUG );
-sub debug { print "\t>>>",@_ if $DEBUG }
+our $DEBUG = 1;
+sub debug { print join '', map "\t# $_\n", map { split /\n/ } @_ if $DEBUG }
 
 ######################### End of black magic.
 
@@ -53,7 +53,7 @@ while (defined($str = <DATA>))
     debug "\t scalar left: [$str]\n";
     print "not " if ($str =~ '\A;')==$neg;
     print "ok ", $count++;
-    print " ($@)" if $@ && $DEBUG;
+    debug " ($@)" if $@;
     print "\n";
 }
 
@@ -97,6 +97,14 @@ __DATA__
 { $a = $b; # what's this doing here? \n };'
 { $a = $b; \n $a =~ /$b/; \n @a = map /\s/ @b };
 
-# THIS SHOULD FAIL
+# THESE SHOULD FAIL
 { $a = $b; # what's this doing here? };'
 { $a = $b; # what's this doing here? ;'
+
+# USING: extract_codeblock($str,'{}');
+{ x1 => 1, z => 2};
+{ x2=> 1, y => 2};
+
+# THESE SHOULD FAIL
+{ x3 => 1, z => 2}, { x => 1, z => 3};
+{ x4 => 1, y => 2}, { x => 1, y => 3};


### PR DESCRIPTION
As described in https://rt.cpan.org/Public/Bug/Display.html?id=96542

I had a PR against an early version on gitpan, but it looks like that got deleted as gitpan is a read-only repo.  Saw that you've taken on maint -- yay! -- so I've updated against your fork, hope it's ok, but let me know if you'd like any rework!

I've made the test debug by default (using a `diag`-like output) to make it slightly easier to debug.
