### PR TITLE
Stop constantly recompiling regex in extract_multiple

### DIFF
--- a/lib/Text/Balanced.pm
+++ b/lib/Text/Balanced.pm
@@ -874,6 +874,7 @@ my $def_func = [
     sub { extract_quotelike($_[0],'') },
     sub { extract_codeblock($_[0],'{}','') },
 ];
+my %ref_not_regex = map +($_=>1), qw(CODE Text::Balanced::Extractor);
 
 sub extract_multiple (;$$$$)    # ($text, $functions_ref, $max_fields, $ignoreunknown)
 {
@@ -913,6 +914,7 @@ sub extract_multiple (;$$$$)    # ($text, $functions_ref, $max_fields, $ignoreun
             {
                 push @class, undef;
             }
+            $func = qr/\G$func/ if !$ref_not_regex{ref $func};
         }
 
         FIELD: while (pos($$textref) < length($$textref))
@@ -929,7 +931,7 @@ sub extract_multiple (;$$$$)    # ($text, $functions_ref, $max_fields, $ignoreun
                     { ($field,$rem,$pref) = @bits = $func->($$textref) }
                 elsif (ref($func) eq 'Text::Balanced::Extractor')
                     { @bits = $field = $func->extract($$textref) }
-                elsif( $$textref =~ m/\G$func/gc )
+                elsif( $$textref =~ m/$func[$i]/gc )
                     { @bits = $field = defined($1)
                         ? $1
                         : substr($$textref, $-[0], $+[0] - $-[0])


### PR DESCRIPTION
With this change, PDL::NiceSlice when used with PDL::LinearAlgebra (a 6700-line file) goes from taking about 10 seconds to be processed using Filter::Simple, to about 0.6s.

The reason is that the regex in `m/\G$func/gc` was constantly being recompiled (in the above case, NYTProf reported it was about 250k times) since `$func` kept being assigned from `$func[$i]`, i.e. changed. By updating it to be recompiled at the start of the function with the `\G` prefixed, then just using the stored version `$func[$i]`, this recompilation is avoided.