### PR TITLE
Fix use warnings

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -130,8 +130,9 @@ MAIN: {
         },
 
         TEST_REQUIRES => {
-            'Test::More' => '0.88', # done_testing
-            'vars'       => '0'
+            'Test::More'       => '0.88', # done_testing
+            'Test::NoWarnings' => 0,
+            'vars'             => '0'
         },
 
         PREREQ_PM => {

--- a/lib/Text/Balanced.pm
+++ b/lib/Text/Balanced.pm
@@ -14,6 +14,7 @@ package Text::Balanced;
 
 use 5.008001;
 use strict;
+use warnings;
 use Exporter ();
 
 use vars qw { $VERSION @ISA %EXPORT_TAGS };

--- a/t/01_compile.t
+++ b/t/01_compile.t
@@ -3,6 +3,7 @@ use 5.008001;
 use strict;
 use warnings;
 
-use Test::More tests => 1;
+use Test::More tests => 2;
+use Test::NoWarnings;
 
 use_ok( 'Text::Balanced' );

--- a/t/02_extbrk.t
+++ b/t/02_extbrk.t
@@ -3,6 +3,7 @@ use 5.008001;
 use strict;
 use warnings;
 use Test::More;
+use Test::NoWarnings qw ( had_no_warnings );
 use Text::Balanced qw ( extract_bracketed );
 
 our $DEBUG;
@@ -39,6 +40,7 @@ while (defined($str = <DATA>))
     diag $@ if $@ && $DEBUG;
 }
 
+had_no_warnings;
 done_testing;
 
 __DATA__

--- a/t/03_extcbk.t
+++ b/t/03_extcbk.t
@@ -3,6 +3,7 @@ use 5.008001;
 use strict;
 use warnings;
 use Test::More;
+use Test::NoWarnings qw ( had_no_warnings );
 use Text::Balanced qw ( extract_codeblock );
 
 our $DEBUG;
@@ -58,6 +59,7 @@ pos $grammar = 26;
 ($out) = extract_codeblock($grammar,'{([',undef,'(',1);
 is $out, '(/b/)', 'PRD error';
 
+had_no_warnings;
 done_testing;
 
 __DATA__

--- a/t/04_extdel.t
+++ b/t/04_extdel.t
@@ -3,6 +3,7 @@ use 5.008001;
 use strict;
 use warnings;
 use Test::More;
+use Test::NoWarnings qw ( had_no_warnings );
 use Text::Balanced qw ( extract_delimited extract_multiple );
 
 our $DEBUG;
@@ -52,6 +53,7 @@ my @fields = extract_multiple($text,
  undef,1);
 is_deeply \@fields, ['a', "'x b'", 'c'] or diag 'got: ', explain \@fields;
 
+had_no_warnings;
 done_testing;
 
 __DATA__

--- a/t/05_extmul.t
+++ b/t/05_extmul.t
@@ -3,6 +3,7 @@ use 5.008001;
 use strict;
 use warnings;
 use Test::More;
+use Test::NoWarnings qw ( had_no_warnings );
 use Text::Balanced qw ( :ALL );
 
 our $DEBUG;
@@ -376,4 +377,5 @@ expect [ extract_multiple($slashmatch, [
 ]) ],
   [ '$_', ' = 1 unless defined ', '$_', ' and ', '/\\d\\b/', ";\n" ];
 
+had_no_warnings;
 done_testing;

--- a/t/06_extqlk.t
+++ b/t/06_extqlk.t
@@ -3,6 +3,7 @@ use 5.008001;
 use strict;
 use warnings;
 use Test::More;
+use Test::NoWarnings qw ( had_no_warnings );
 use Text::Balanced qw ( extract_quotelike );
 
 our $DEBUG;
@@ -64,6 +65,7 @@ like $z[1], qr/\A,/, 'implied heredoc with ,' or do {
   diag "error: '$@'\ngot: ", explain \@z;
 };
 
+had_no_warnings;
 done_testing;
 
 __DATA__

--- a/t/07_exttag.t
+++ b/t/07_exttag.t
@@ -3,6 +3,7 @@ use 5.008001;
 use strict;
 use warnings;
 use Test::More;
+use Test::NoWarnings qw ( had_no_warnings );
 use Text::Balanced qw ( extract_tagged gen_extract_tagged );
 
 our $DEBUG;
@@ -40,6 +41,7 @@ while (defined($str = <DATA>))
     ($neg ? \&unlike : \&like)->( $str, qr/\A;/, "$orig_str matched scalar");
 }
 
+had_no_warnings;
 done_testing;
 
 __DATA__

--- a/t/08_extvar.t
+++ b/t/08_extvar.t
@@ -3,6 +3,7 @@ use 5.008001;
 use strict;
 use warnings;
 use Test::More;
+use Test::NoWarnings qw ( had_no_warnings );
 use Text::Balanced qw ( extract_variable );
 
 our $DEBUG;
@@ -43,6 +44,7 @@ while (defined($str = <DATA>))
 my @res = extract_variable('${a}');
 is $res[0], '${a}' or diag "error was: $@";
 
+had_no_warnings;
 done_testing;
 
 __DATA__

--- a/t/09_gentag.t
+++ b/t/09_gentag.t
@@ -3,6 +3,7 @@ use 5.008001;
 use strict;
 use warnings;
 use Text::Balanced qw ( gen_extract_tagged );
+use Test::NoWarnings qw ( had_no_warnings );
 use Test::More;
 
 our $DEBUG;
@@ -52,6 +53,7 @@ while (defined($str = <DATA>))
     ($neg ? \&unlike : \&like)->( $str, qr/\A;/, "$orig_str matched scalar");
 }
 
+had_no_warnings;
 done_testing;
 
 __DATA__


### PR DESCRIPTION
This PR is adding warnings to the module and checking warnings in tests. Related to the issue fixed in https://github.com/steve-m-hay/Text-Balanced/pull/8
Otherwise, we blindly ignore the warning generated by the module.

Example output before fix in https://github.com/steve-m-hay/Text-Balanced/pull/8:
```make test```
```
PERL_DL_NONLAZY=1 "/usr/bin/perl" "-MExtUtils::Command::MM" "-MTest::Harness" "-e" "undef *Test::Harness::Switches; test_harness(0, 'blib/lib', 'blib/arch')" t/*.t
t/01_compile.t ....... ok
t/02_extbrk.t ........ ok
t/03_extcbk.t ........ ok

#   Failed test 'no warnings'
#   at t/04_extdel.t line 56.
# There were 4 warning(s)
#     Previous test 89 'string overload should not crash'
#     Use of uninitialized value $unkpos in subtraction (-) at /home/skim/44_git/Text-Balanced/blib/lib/Text/Balanced.pm line 1009, <DATA> line 38.
#  at /home/skim/44_git/Text-Balanced/blib/lib/Text/Balanced.pm line 1009, <DATA> line 38.
#       Text::Balanced::extract_multiple("a,'x b',c", ARRAY(0x5593127a42c8), undef, 1) called at t/04_extdel.t line 51
#
# ----------
#     Previous test 89 'string overload should not crash'
#     Use of uninitialized value $unkpos in substr at /home/skim/44_git/Text-Balanced/blib/lib/Text/Balanced.pm line 1009, <DATA> line 38.
#  at /home/skim/44_git/Text-Balanced/blib/lib/Text/Balanced.pm line 1009, <DATA> line 38.
#       Text::Balanced::extract_multiple("a,'x b',c", ARRAY(0x5593127a42c8), undef, 1) called at t/04_extdel.t line 51
#
# ----------
#     Previous test 89 'string overload should not crash'
#     Use of uninitialized value $unkpos in subtraction (-) at /home/skim/44_git/Text-Balanced/blib/lib/Text/Balanced.pm line 1009, <DATA> line 38.
#  at /home/skim/44_git/Text-Balanced/blib/lib/Text/Balanced.pm line 1009, <DATA> line 38.
#       Text::Balanced::extract_multiple("a,'x b',c", ARRAY(0x5593127a42c8), undef, 1) called at t/04_extdel.t line 51
#
# ----------
#     Previous test 89 'string overload should not crash'
#     Use of uninitialized value $unkpos in substr at /home/skim/44_git/Text-Balanced/blib/lib/Text/Balanced.pm line 1009, <DATA> line 38.
#  at /home/skim/44_git/Text-Balanced/blib/lib/Text/Balanced.pm line 1009, <DATA> line 38.
#       Text::Balanced::extract_multiple("a,'x b',c", ARRAY(0x5593127a42c8), undef, 1) called at t/04_extdel.t line 51
#
# Looks like you failed 1 test of 91.
t/04_extdel.t ........
Dubious, test returned 1 (wstat 256, 0x100)
Failed 1/91 subtests

#   Failed test 'no warnings'
#   at t/05_extmul.t line 380.
# There were 72 warning(s)
#     Previous test 54 ''
#     Use of uninitialized value $unkpos in subtraction (-) at /home/skim/44_git/Text-Balanced/blib/lib/Text/Balanced.pm line 1009.
#  at /home/skim/44_git/Text-Balanced/blib/lib/Text/Balanced.pm line 1009.
#       Text::Balanced::extract_multiple("\$var = \"val\" && (1,2,3);", ARRAY(0x55bbae7b6448), 2, 1) called at t/05_extmul.t line 178
#
# ----------
#     Previous test 54 ''
#     Use of uninitialized value $unkpos in substr at /home/skim/44_git/Text-Balanced/blib/lib/Text/Balanced.pm line 1009.
#  at /home/skim/44_git/Text-Balanced/blib/lib/Text/Balanced.pm line 1009.
#       Text::Balanced::extract_multiple("\$var = \"val\" && (1,2,3);", ARRAY(0x55bbae7b6448), 2, 1) called at t/05_extmul.t line 178
#
# ----------
#     Previous test 54 ''
#     Use of uninitialized value $unkpos in subtraction (-) at /home/skim/44_git/Text-Balanced/blib/lib/Text/Balanced.pm line 1009.
#  at /home/skim/44_git/Text-Balanced/blib/lib/Text/Balanced.pm line 1009.
#       Text::Balanced::extract_multiple("\$var = \"val\" && (1,2,3);", ARRAY(0x55bbae7b6448), 2, 1) called at t/05_extmul.t line 178
#
# ----------
#     Previous test 54 ''
#     Use of uninitialized value $unkpos in substr at /home/skim/44_git/Text-Balanced/blib/lib/Text/Balanced.pm line 1009.
#  at /home/skim/44_git/Text-Balanced/blib/lib/Text/Balanced.pm line 1009.
#       Text::Balanced::extract_multiple("\$var = \"val\" && (1,2,3);", ARRAY(0x55bbae7b6448), 2, 1) called at t/05_extmul.t line 178
#
# ----------
#     Previous test 54 ''
#     Use of uninitialized value $unkpos in subtraction (-) at /home/skim/44_git/Text-Balanced/blib/lib/Text/Balanced.pm line 1009.
#  at /home/skim/44_git/Text-Balanced/blib/lib/Text/Balanced.pm line 1009.
#       Text::Balanced::extract_multiple("\$var = \"val\" && (1,2,3);", ARRAY(0x55bbae7b6448), 2, 1) called at t/05_extmul.t line 178
#
# ----------
#     Previous test 54 ''
#     Use of uninitialized value $unkpos in substr at /home/skim/44_git/Text-Balanced/blib/lib/Text/Balanced.pm line 1009.
#  at /home/skim/44_git/Text-Balanced/blib/lib/Text/Balanced.pm line 1009.
#       Text::Balanced::extract_multiple("\$var = \"val\" && (1,2,3);", ARRAY(0x55bbae7b6448), 2, 1) called at t/05_extmul.t line 178
#
# ----------
#     Previous test 54 ''
#     Use of uninitialized value $unkpos in subtraction (-) at /home/skim/44_git/Text-Balanced/blib/lib/Text/Balanced.pm line 1009.
#  at /home/skim/44_git/Text-Balanced/blib/lib/Text/Balanced.pm line 1009.
#       Text::Balanced::extract_multiple("\$var = \"val\" && (1,2,3);", ARRAY(0x55bbae7b6448), 2, 1) called at t/05_extmul.t line 178
#
# ----------
#     Previous test 54 ''
#     Use of uninitialized value $unkpos in substr at /home/skim/44_git/Text-Balanced/blib/lib/Text/Balanced.pm line 1009.
#  at /home/skim/44_git/Text-Balanced/blib/lib/Text/Balanced.pm line 1009.
#       Text::Balanced::extract_multiple("\$var = \"val\" && (1,2,3);", ARRAY(0x55bbae7b6448), 2, 1) called at t/05_extmul.t line 178
#
# ----------
#     Previous test 54 ''
#     Use of uninitialized value $unkpos in subtraction (-) at /home/skim/44_git/Text-Balanced/blib/lib/Text/Balanced.pm line 1009.
#  at /home/skim/44_git/Text-Balanced/blib/lib/Text/Balanced.pm line 1009.
#       Text::Balanced::extract_multiple("\$var = \"val\" && (1,2,3);", ARRAY(0x55bbae7b6448), 2, 1) called at t/05_extmul.t line 178
#
# ----------
#     Previous test 54 ''
#     Use of uninitialized value $unkpos in substr at /home/skim/44_git/Text-Balanced/blib/lib/Text/Balanced.pm line 1009.
#  at /home/skim/44_git/Text-Balanced/blib/lib/Text/Balanced.pm line 1009.
#       Text::Balanced::extract_multiple("\$var = \"val\" && (1,2,3);", ARRAY(0x55bbae7b6448), 2, 1) called at t/05_extmul.t line 178
#
# ----------
#     Previous test 54 ''
#     Use of uninitialized value $unkpos in subtraction (-) at /home/skim/44_git/Text-Balanced/blib/lib/Text/Balanced.pm line 1009.
#  at /home/skim/44_git/Text-Balanced/blib/lib/Text/Balanced.pm line 1009.
#       Text::Balanced::extract_multiple("\$var = \"val\" && (1,2,3);", ARRAY(0x55bbae7b6448), 2, 1) called at t/05_extmul.t line 178
#
# ----------
#     Previous test 54 ''
#     Use of uninitialized value $unkpos in substr at /home/skim/44_git/Text-Balanced/blib/lib/Text/Balanced.pm line 1009.
#  at /home/skim/44_git/Text-Balanced/blib/lib/Text/Balanced.pm line 1009.
#       Text::Balanced::extract_multiple("\$var = \"val\" && (1,2,3);", ARRAY(0x55bbae7b6448), 2, 1) called at t/05_extmul.t line 178
#
# ----------
#     Previous test 54 ''
#     Use of uninitialized value $unkpos in subtraction (-) at /home/skim/44_git/Text-Balanced/blib/lib/Text/Balanced.pm line 1009.
#  at /home/skim/44_git/Text-Balanced/blib/lib/Text/Balanced.pm line 1009.
#       Text::Balanced::extract_multiple("\$var = \"val\" && (1,2,3);", ARRAY(0x55bbae7b6448), 2, 1) called at t/05_extmul.t line 178
#
# ----------
...
#     Previous test 63 ''
#     Use of uninitialized value $unkpos in substr at /home/skim/44_git/Text-Balanced/blib/lib/Text/Balanced.pm line 1009.
#  at /home/skim/44_git/Text-Balanced/blib/lib/Text/Balanced.pm line 1009.
#       Text::Balanced::extract_multiple("\$var = \"val\" && (1,2,3);", ARRAY(0x55bbae7fc5e8), 1, 1) called at t/05_extmul.t line 200
#
# Looks like you failed 1 test of 97.
t/05_extmul.t ........
Dubious, test returned 1 (wstat 256, 0x100)
Failed 1/97 subtests
t/06_extqlk.t ........ ok
t/07_exttag.t ........ ok
t/08_extvar.t ........ ok
t/09_gentag.t ........ ok
t/94_changes.t ....... skipped: Author testing only
t/95_critic.t ........ skipped: Author testing only
t/96_pmv.t ........... skipped: Author testing only
t/97_pod.t ........... skipped: Author testing only
t/98_pod_coverage.t .. skipped: Author testing only

Test Summary Report
-------------------
t/04_extdel.t      (Wstat: 256 (exited 1) Tests: 91 Failed: 1)
  Failed test:  91
  Non-zero exit status: 1
t/05_extmul.t      (Wstat: 256 (exited 1) Tests: 97 Failed: 1)
  Failed test:  97
  Non-zero exit status: 1
Files=14, Tests=1103,  1 wallclock secs ( 0.14 usr  0.03 sys +  1.03 cusr  0.16 csys =  1.36 CPU)
Result: FAIL
Failed 2/14 test programs. 2/1103 subtests failed.
make: *** [Makefile:956: test_dynamic] Chyba 255
```